### PR TITLE
Avoid duplicate resource declarations

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,4 @@
 # @!visibility private
 class sasl::install {
-
-  package { $::sasl::package_name:
-    ensure => present,
-  }
+  ensure_packages($sasl::package_name, {'ensure' =>  'present'})
 }


### PR DESCRIPTION
This PR will resolve duplicate resource declarations.

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Duplicate declaration: Package[cyrus-sasl-lib] is already declared at (file: /etc/puppetlabs/code/environments/production/modules/sasl/manifests/install.pp, line: 4); cannot redeclare (file: /etc/puppetlabs/code/environments/production/modules/sasl/manifests/application.pp, line: 94) (file: /etc/puppetlabs/code/environments/production/modules/sasl/manifests/application.pp, line: 94, column: 7)